### PR TITLE
Changes to support historical event info

### DIFF
--- a/frontend/src/app/matches.ts
+++ b/frontend/src/app/matches.ts
@@ -1,149 +1,25 @@
 export class Matches {
-    actualTime: string;
     blue1: string;
     blue2: string;
     blue3: string;
-    blueAutoPts: number;
-
-    blueEndgameCSPts: number;
-    blueLinkPts: number;
-    blueTotalPts: number;
-    blueTelePts: number;
-    blueFouls: number;
-    blueCoopertitionBonus: number;
-    blueTechFouls: number;
-    blueTotalCSPts: number;
-    blueCoopGamePieceCount: number;
-    blueActivationBonus: number;
-    blueSustainabilityBonus: number;
-    blueAutoMoveBonusPts: number;
-    blueAutoGamePieces: number;
-    blueAutoGamePiecePts: number;
-    blueAutoCSPts: number;
-    blueTeleGamePieces: number;
-    blueTeleGamePiecePts: number;
-    eventID	: number;
-    matchID: number;
     matchNum: number;
-    matchTime: string;
     red1: string;
     red2: string;
     red3: string ;
-    redTeleGamePiecePts: number;
-    redTeleGamePieces: number;
-    redAutoCSPts: number;
-    redAutoGamePiecePts: number;
-    redAutoMoveBonusPts: number;
-    redAutoGamePieces: number;
-    redSustainabilityBonus: number;
-    redCoopertitionBonus: number;
-    redTotalCSPts: number;
-    redCoopGamePieceCount: number;
-    redActivationBonus: number;
-    redAutoPts: number;
-    redEndgameCSPts: number;
-    redLinkPts: number;
-    redTotalPts: number;
-    redTelePts: number;
-    redFouls: number;
-    redTechFouls: number;
-
 constructor(actualTime: string,
     blue1: string,
     blue2: string,
     blue3: string,
-    blueTotalCSPts: number,
-    blueLinkPts: number,
-    blueCoopGamePieceCount: number,
-    blueActivationBonus: number,
-    blueSustainabilityBonus: number,
-    blueAutoMoveBonusPts: number,
-    blueAutoGamePieces: number,
-    blueAutoGamePiecePts: number,
-    blueAutoCSPts: number,
-    blueTeleGamePieces: number,
-    blueTeleGamePiecePts: number,
-    blueAutoPts: number,
-    blueCoopertitionBonus: number,
-    blueEndgameCSPts: number,
-    
-    blueTotalPts: number,
-    blueTelePts: number,
-    blueFouls: number,
-    blueTechFouls: number,
-    eventID	: number,
-    matchID: number,
     matchNum: number,
-    matchTime: string,
     red1: string,
     red2: string,
-    red3: string ,
-    redAutoPts: number,
-    redTeleGamePiecePts: number,
-    redTeleGamePieces: number,
-    redAutoCSPts: number,
-    redAutoGamePiecePts: number,
-    redAutoMoveBonusPts: number,
-    redAutoGamePieces: number,
-    redSustainabilityBonus: number,
-    redCoopertitionBonus: number,
-    redTotalCSPts: number,
-    redLinkPts: number,
-    redCoopGamePieceCount: number,
-    redActivationBonus: number,
-    redEndgameCSPts: number,
-    redTotalPts: number,
-    redTelePts: number,
-    redFouls: number,
-    redTechFouls: number
+    red3: string
     ){
-        this.actualTime=actualTime;
         this.blue1=blue1;
         this.blue2=blue2;
         this.blue3=blue3;
-        this.blueTotalCSPts = blueTotalCSPts;
-    this.blueCoopGamePieceCount= blueCoopGamePieceCount;
-    this.blueActivationBonus= blueActivationBonus;
-    this.blueSustainabilityBonus= blueSustainabilityBonus;
-    this.blueAutoMoveBonusPts= blueAutoMoveBonusPts;
-    this.blueAutoGamePieces= blueAutoGamePieces;
-    this.blueAutoGamePiecePts= blueAutoGamePiecePts;
-    this.blueAutoCSPts= blueAutoCSPts;
-    this.blueTeleGamePieces= blueTeleGamePieces;
-    this.blueTeleGamePiecePts = blueTeleGamePiecePts;
-    this.blueCoopertitionBonus= blueCoopertitionBonus;
-        this.blueAutoPts=blueAutoPts;
-        this.blueEndgameCSPts=blueEndgameCSPts;
-        this.blueLinkPts=blueLinkPts;
-        this.blueTotalPts=blueTotalPts;
-        this.blueTelePts=blueTelePts;
-        this.blueFouls=blueFouls;
-        this.blueTechFouls=blueTechFouls;
-        this.eventID=eventID	;
-        this.matchID=matchID;
         this.matchNum=matchNum;
-        this.matchTime=matchTime;
         this.red1=red1;
         this.red2=red2;
-        this.red3=red3;
-        this.redAutoPts=redAutoPts;
-        this.redEndgameCSPts=redEndgameCSPts;
-        this.redLinkPts=redLinkPts;
-        this.redTotalPts=redTotalPts;
-        this.redTelePts=redTelePts;
-        this.redFouls=redFouls;
-        this.redTechFouls=redTechFouls;
-        this.redTeleGamePiecePts = redTeleGamePiecePts;
-    this.redTeleGamePieces = redTeleGamePieces;
-    this.redAutoCSPts = redAutoCSPts;
-    this.redAutoGamePiecePts= redAutoGamePiecePts;
-    this.redAutoMoveBonusPts= redAutoMoveBonusPts;
-    this.redAutoGamePieces = redAutoGamePieces;
-    this.redSustainabilityBonus = redSustainabilityBonus;
-    this.redCoopertitionBonus = redCoopertitionBonus;
-    this.redTotalCSPts = redTotalCSPts;
-    this.redLinkPts = redLinkPts;
-    this.redCoopGamePieceCount= redCoopGamePieceCount;
-    this.redActivationBonus = redActivationBonus;
-       
+        this.red3=red3;       
 }}

--- a/frontend/src/app/matchinfo.ts
+++ b/frontend/src/app/matchinfo.ts
@@ -1,0 +1,149 @@
+export class MatchInfo {
+    actualTime: string;
+    blue1: string;
+    blue2: string;
+    blue3: string;
+    blueAutoPts: number;
+
+    blueEndgameCSPts: number;
+    blueLinkPts: number;
+    blueTotalPts: number;
+    blueTelePts: number;
+    blueFouls: number;
+    blueCoopertitionBonus: number;
+    blueTechFouls: number;
+    blueTotalCSPts: number;
+    blueCoopGamePieceCount: number;
+    blueActivationBonus: number;
+    blueSustainabilityBonus: number;
+    blueAutoMoveBonusPts: number;
+    blueAutoGamePieces: number;
+    blueAutoGamePiecePts: number;
+    blueAutoCSPts: number;
+    blueTeleGamePieces: number;
+    blueTeleGamePiecePts: number;
+    eventID	: number;
+    matchID: number;
+    matchNum: number;
+    matchTime: string;
+    red1: string;
+    red2: string;
+    red3: string ;
+    redTeleGamePiecePts: number;
+    redTeleGamePieces: number;
+    redAutoCSPts: number;
+    redAutoGamePiecePts: number;
+    redAutoMoveBonusPts: number;
+    redAutoGamePieces: number;
+    redSustainabilityBonus: number;
+    redCoopertitionBonus: number;
+    redTotalCSPts: number;
+    redCoopGamePieceCount: number;
+    redActivationBonus: number;
+    redAutoPts: number;
+    redEndgameCSPts: number;
+    redLinkPts: number;
+    redTotalPts: number;
+    redTelePts: number;
+    redFouls: number;
+    redTechFouls: number;
+
+constructor(actualTime: string,
+    blue1: string,
+    blue2: string,
+    blue3: string,
+    blueTotalCSPts: number,
+    blueLinkPts: number,
+    blueCoopGamePieceCount: number,
+    blueActivationBonus: number,
+    blueSustainabilityBonus: number,
+    blueAutoMoveBonusPts: number,
+    blueAutoGamePieces: number,
+    blueAutoGamePiecePts: number,
+    blueAutoCSPts: number,
+    blueTeleGamePieces: number,
+    blueTeleGamePiecePts: number,
+    blueAutoPts: number,
+    blueCoopertitionBonus: number,
+    blueEndgameCSPts: number,
+    
+    blueTotalPts: number,
+    blueTelePts: number,
+    blueFouls: number,
+    blueTechFouls: number,
+    eventID	: number,
+    matchID: number,
+    matchNum: number,
+    matchTime: string,
+    red1: string,
+    red2: string,
+    red3: string ,
+    redAutoPts: number,
+    redTeleGamePiecePts: number,
+    redTeleGamePieces: number,
+    redAutoCSPts: number,
+    redAutoGamePiecePts: number,
+    redAutoMoveBonusPts: number,
+    redAutoGamePieces: number,
+    redSustainabilityBonus: number,
+    redCoopertitionBonus: number,
+    redTotalCSPts: number,
+    redLinkPts: number,
+    redCoopGamePieceCount: number,
+    redActivationBonus: number,
+    redEndgameCSPts: number,
+    redTotalPts: number,
+    redTelePts: number,
+    redFouls: number,
+    redTechFouls: number
+    ){
+        this.actualTime=actualTime;
+        this.blue1=blue1;
+        this.blue2=blue2;
+        this.blue3=blue3;
+        this.blueTotalCSPts = blueTotalCSPts;
+    this.blueCoopGamePieceCount= blueCoopGamePieceCount;
+    this.blueActivationBonus= blueActivationBonus;
+    this.blueSustainabilityBonus= blueSustainabilityBonus;
+    this.blueAutoMoveBonusPts= blueAutoMoveBonusPts;
+    this.blueAutoGamePieces= blueAutoGamePieces;
+    this.blueAutoGamePiecePts= blueAutoGamePiecePts;
+    this.blueAutoCSPts= blueAutoCSPts;
+    this.blueTeleGamePieces= blueTeleGamePieces;
+    this.blueTeleGamePiecePts = blueTeleGamePiecePts;
+    this.blueCoopertitionBonus= blueCoopertitionBonus;
+        this.blueAutoPts=blueAutoPts;
+        this.blueEndgameCSPts=blueEndgameCSPts;
+        this.blueLinkPts=blueLinkPts;
+        this.blueTotalPts=blueTotalPts;
+        this.blueTelePts=blueTelePts;
+        this.blueFouls=blueFouls;
+        this.blueTechFouls=blueTechFouls;
+        this.eventID=eventID	;
+        this.matchID=matchID;
+        this.matchNum=matchNum;
+        this.matchTime=matchTime;
+        this.red1=red1;
+        this.red2=red2;
+        this.red3=red3;
+        this.redAutoPts=redAutoPts;
+        this.redEndgameCSPts=redEndgameCSPts;
+        this.redLinkPts=redLinkPts;
+        this.redTotalPts=redTotalPts;
+        this.redTelePts=redTelePts;
+        this.redFouls=redFouls;
+        this.redTechFouls=redTechFouls;
+        this.redTeleGamePiecePts = redTeleGamePiecePts;
+    this.redTeleGamePieces = redTeleGamePieces;
+    this.redAutoCSPts = redAutoCSPts;
+    this.redAutoGamePiecePts= redAutoGamePiecePts;
+    this.redAutoMoveBonusPts= redAutoMoveBonusPts;
+    this.redAutoGamePieces = redAutoGamePieces;
+    this.redSustainabilityBonus = redSustainabilityBonus;
+    this.redCoopertitionBonus = redCoopertitionBonus;
+    this.redTotalCSPts = redTotalCSPts;
+    this.redLinkPts = redLinkPts;
+    this.redCoopGamePieceCount= redCoopGamePieceCount;
+    this.redActivationBonus = redActivationBonus;
+       
+}}

--- a/frontend/src/app/modules/match-info/match-info.component.ts
+++ b/frontend/src/app/modules/match-info/match-info.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ApiService } from 'src/app/services/api.service';
-import { Matches } from '../../matches'
+import { MatchInfo } from '../../matchinfo';
 
 @Component({
   selector: 'app-match-info',
@@ -13,11 +13,11 @@ export class MatchInfoComponent implements OnInit {
   showAuto: number=0;
   showTele: number=0;
   showCoop: number=0;
-  apiMatchList: Matches[];
+  apiMatchList: MatchInfo[];
   constructor(private apiService: ApiService) {
     this.match=0;
     this.apiMatchList = [];
-    this.apiService.MatchReplay.subscribe(match => {
+    this.apiService.MatchInfoReplay.subscribe(match => {
       this.apiMatchList = match;
     });
    }

--- a/frontend/src/app/modules/schedule/schedule.component.ts
+++ b/frontend/src/app/modules/schedule/schedule.component.ts
@@ -2,7 +2,7 @@ import { C } from '@angular/cdk/keycodes';
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Router } from '@angular/router';
 import { ApiService, CurrTeams, Final24 } from 'src/app/services/api.service';
-import { Matches } from '../../matches';
+import { MatchInfo } from '../../matchinfo';
 
 export interface TeamMatch {
   Team: string;
@@ -41,8 +41,8 @@ export class ScheduleComponent implements OnInit {
   apiWatch1List: Final24[]=[];
   apiWatch2List: Final24[]=[];
 
-  apiMatchList: Matches[];
-  apiMatchList_filter: Matches[]; 
+  apiMatchList: MatchInfo[];
+  apiMatchList_filter: MatchInfo[]; 
   apiCurrTeamList: CurrTeams[];
 
   teamMatch: TeamMatch[] = [];
@@ -68,7 +68,7 @@ export class ScheduleComponent implements OnInit {
     this.apiCurrTeamList = [];
     this.selectedMatch = 0;
 
-    this.apiService.MatchReplay.subscribe(match => {
+    this.apiService.MatchInfoReplay.subscribe(match => {
       this.apiMatchList = match;
       this.regenerateFilter();
     });


### PR DESCRIPTION
Separated MatchInfo from Matches so that we can pull the match list for the current event even when we are looking at past event info.  The schedule and match info will show historical info, while the match reports will be related to the current event.